### PR TITLE
[식당 세부화면] 신규 등록 레스토랑 세부화면 조회 정상화

### DIFF
--- a/templates/showRestaurantDetail.html
+++ b/templates/showRestaurantDetail.html
@@ -11,7 +11,6 @@
       crossorigin="anonymous"
     ></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='showRestaurantDetail.css') }}">
-
 {% endblock %}
 
 {% block section %}


### PR DESCRIPTION
백엔드 팀 작업

- 신규 등록한 레스토랑의 경우, 식당 리스트 조회화면에서 식당 세부화면으로 넘어가지 않는 에러를 해결하였습니다.
- => 신규 등록한 레스토랑의 경우 리뷰가 아직 없기 때문에 에러가 났음. len(rates) if 문을 생성해 문제 해결함.